### PR TITLE
Update to v0.0.7rc1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 *********
 
+0.0.7rc1
+-----
+
+* Update requirements to wagtail > 2.4, no upper limit
+* Add colourpicker.css and colourpicker.js, per AlexDeltax
+
 0.0.6
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from wagtailcolourpicker import __version__
 
 
 install_requires = [
-    'wagtail>=2'
+    'wagtail>=2.4'
 ]
 
 documentation_extras = [

--- a/wagtailcolourpicker/__init__.py
+++ b/wagtailcolourpicker/__init__.py
@@ -2,6 +2,6 @@ from wagtailcolourpicker.utils.version import get_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (0, 0, 6, 'final', 0)
+VERSION = (0, 0, 7, 'rc', 1)
 
 __version__ = get_version(VERSION)

--- a/wagtailcolourpicker/utils/version.py
+++ b/wagtailcolourpicker/utils/version.py
@@ -5,7 +5,7 @@ def get_version(version):
 
     sub = ''
     if version[3] != 'final':
-        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}
         sub = mapping[version[3]] + str(version[4])
 
     return main + sub


### PR DESCRIPTION
To allow me to distinguish 'vanilla' v0.0.6 from your fork, I bumped up the version number. I found a little bug in the version object when I did that.